### PR TITLE
Update instruction template to use GitHub API

### DIFF
--- a/PROJECT_INSTRUCTION_TEMPLATE.md
+++ b/PROJECT_INSTRUCTION_TEMPLATE.md
@@ -1,5 +1,8 @@
 # Claude Project Instructions
 
-Use project instructions at: https://github.com/zbynekdrlik/claude-dev-template/blob/main/LLM_INSTRUCTIONS.md
+Read project instructions using GitHub API from:
+- Repository: zbynekdrlik/claude-dev-template
+- File: LLM_INSTRUCTIONS.md
+- Branch: main
 
-Your working GitHub URL is: https://github.com/zbynekdrlik/[REPOSITORY-NAME]
+Your working GitHub repository is: https://github.com/zbynekdrlik/[REPOSITORY-NAME]


### PR DESCRIPTION
This PR updates the PROJECT_INSTRUCTION_TEMPLATE.md to provide clearer instructions for Claude to use GitHub API for reading the LLM instructions.

## Changes:
- Replaced URL reference with explicit GitHub API instructions
- Specified repository, file, and branch for API access
- Removed URL that Claude cannot fetch directly

## New format:
```markdown
Read project instructions using GitHub API from:
- Repository: zbynekdrlik/claude-dev-template
- File: LLM_INSTRUCTIONS.md
- Branch: main
```

## Testing:
I've tested that Claude can successfully read the LLM_INSTRUCTIONS.md file using the GitHub API with these parameters. The API approach works reliably, whereas direct URL fetching was not permitted.

This ensures Claude can always access the centralized instructions properly.