### PR TITLE
Add support for reading rules from /rules/ directory

### DIFF
--- a/LLM_INSTRUCTIONS.md
+++ b/LLM_INSTRUCTIONS.md
@@ -13,6 +13,13 @@
    - Flag any code-documentation discrepancies
    - Every change must be incorporated into docs to enable rebuilding from scratch
 
+3. **Rules Directory Check**
+   - Check if repository contains a `/rules/` directory
+   - If `/rules/` exists, read ALL documents from it using the **active feature branch**
+   - **IMPORTANT**: Always read rules from the feature branch you're working on, not from main
+   - Incorporate all rules into the development process
+   - Rules override or supplement these general instructions
+
 ## Development Rules
 
 ### Version Control (CRITICAL)
@@ -82,10 +89,12 @@ Adapt to project's existing structure:
 - Numbered documentation (if `XX-name.md` pattern)
 - Standard directories (if `/docs/` structure)
 - Integration requirements (MCP, API, etc.)
+- Project-specific rules (if `/rules/` directory exists)
 
 ## Quick Checklist
 - [ ] Using feature branch (not main)
 - [ ] Following project documentation structure
+- [ ] Checked and read all rules from `/rules/` directory (if exists)
 - [ ] Version incremented and shown in chat
 - [ ] Version logging implemented on startup
 - [ ] PR created/updated
@@ -101,3 +110,4 @@ Adapt to project's existing structure:
 4. **Documentation First**: Keep docs in sync with code
 5. **User Verification**: Always get logs and approval
 6. **Project Consistency**: Follow existing patterns
+7. **Rules Priority**: Project-specific rules in `/rules/` take precedence


### PR DESCRIPTION
This PR adds support for reading project-specific rules from a `/rules/` directory, ensuring Claude always reads from the active feature branch during development.

## Changes to LLM_INSTRUCTIONS.md:

### 1. Added new section "Rules Directory Check" in Thread Initialization:
```markdown
3. **Rules Directory Check**
   - Check if repository contains a `/rules/` directory
   - If `/rules/` exists, read ALL documents from it using the **active feature branch**
   - **IMPORTANT**: Always read rules from the feature branch you're working on, not from main
   - Incorporate all rules into the development process
   - Rules override or supplement these general instructions
```

### 2. Updated Project-Specific Patterns section:
- Added "Project-specific rules (if `/rules/` directory exists)"

### 3. Updated Quick Checklist:
- Added "Checked and read all rules from `/rules/` directory (if exists)"

### 4. Added new Key Principle:
- "Rules Priority: Project-specific rules in `/rules/` take precedence"

## Key benefits:
1. Projects can maintain specific rules in `/rules/` directory
2. Rules are always read from the active feature branch for consistency
3. Allows for rule updates to be tested alongside code changes
4. Maintains separation between general instructions and project-specific rules
5. Ensures Claude always works with the most current rules during feature development

This pattern allows projects to customize Claude's behavior while maintaining the core instruction set.